### PR TITLE
Encrypt address

### DIFF
--- a/Controllers/inputController.py
+++ b/Controllers/inputController.py
@@ -213,3 +213,20 @@ class InputControl:
           except:
                pass
           return user_data
+
+     def encrypt_address_data(self, address_data: dict) -> dict:
+          for i in range(len(address_data['address'])):
+               address_data['address'][i]['address_neighbourhood'] = ac.encrypt(address_data['address'][i]['address_neighbourhood'], config.CRYPT_KEY)
+               address_data['address'][i]['address_postal_code'] = ac.encrypt(address_data['address'][i]['address_postal_code'], config.CRYPT_KEY)
+               address_data['address'][i]['address_city'] = ac.encrypt(address_data['address'][i]['address_city'], config.CRYPT_KEY)
+               address_data['address'][i]['address_state'] = ac.encrypt(address_data['address'][i]['address_state'], config.CRYPT_KEY)
+          return address_data['address']
+
+     def decrypt_address_data(self, address_data: dict) -> dict:
+          for i in range(len(address_data['address'])):
+               address_data['address'][i]['address_neighbourhood'] = ac.decrypt(address_data['address'][i]['address_neighbourhood'], config.CRYPT_KEY)
+               address_data['address'][i]['address_postal_code'] = ac.decrypt(address_data['address'][i]['address_postal_code'], config.CRYPT_KEY)
+               address_data['address'][i]['address_city'] = ac.decrypt(address_data['address'][i]['address_city'], config.CRYPT_KEY)
+               address_data['address'][i]['address_state'] = ac.decrypt(address_data['address'][i]['address_state'], config.CRYPT_KEY)
+          return address_data['address']
+     

--- a/Controllers/routeController.py
+++ b/Controllers/routeController.py
@@ -128,10 +128,18 @@ class RouteControl:
         verify_address = ic.verify_address_requirements(address_data)
         if verify_address[1] != 200:
             return verify_address
+        address_data['address'] = ic.encrypt_address_data(address_data)
+        
         return db.update_user_by_id(db.id_creation(user_id), dict(address=address_data['address']))
 
     def get_user_by_id_route(self, id: str) -> tuple:
-        return db.get_user_by_id(db.id_creation(id))
+        user_data = db.get_user_by_id(db.id_creation(id))
+        try:
+            if user_data[0]['address']:
+                user_data[0]['address'] = ic.decrypt_address_data(user_data[0])
+        except:
+            pass
+        return user_data
 
     def change_password_route(self, user_data: dict) -> tuple:
         """Controller da rota de troca de senha

--- a/Tests/TestControllers/test_inputController.py
+++ b/Tests/TestControllers/test_inputController.py
@@ -252,3 +252,36 @@ class TestInputController(TestCase):
             encripted_user_data['password']
         ]
         self.assertEqual(ic.encrypt_register_data(user_data), encripted_user_data)
+
+    @mock.patch("Controllers.authController.AuthControl.encrypt")
+    def test_encrypt_address_data_works(self, mock_encrypt):
+        mock_encrypt.return_value = ""
+        address_data = {
+            "address": [
+                {
+                    "address_number": 77,
+                    "address_neighbourhood": "Bairro",
+                    "address_postal_code": "00000000",
+                    "address_city": "Florianópolis",
+                    "address_state": "SC"
+                }
+            ]
+        }
+        self.assertEqual(ic.encrypt_address_data(address_data), address_data['address'])
+    
+    @mock.patch("Controllers.authController.AuthControl.decrypt")
+    def test_decrypt_address_data_works(self, mock_decrypt):
+        mock_decrypt.return_value = ""
+        address_data = {
+            "address": [
+                {
+                    "address_number": 77,
+                    "address_neighbourhood": "Bairro",
+                    "address_postal_code": "00000000",
+                    "address_city": "Florianópolis",
+                    "address_state": "SC"
+                }
+            ]
+        }
+        self.assertEqual(ic.decrypt_address_data(address_data), address_data['address'])
+

--- a/Tests/TestControllers/test_routeController.py
+++ b/Tests/TestControllers/test_routeController.py
@@ -44,16 +44,29 @@ class TestRouteController(TestCase):
         mock_get_user_by_email.return_value = ([''], 404)
         self.assertEqual(rc.register_route(user_data)[1], 201)
 
+    @mock.patch("Controllers.inputController.InputControl.decrypt_address_data")
     @mock.patch("DataBase.dataBase.DataBase.id_creation")
     @mock.patch("DataBase.dataBase.DataBase.get_user_by_id")
-    def test_get_user_by_id_route(self, mock_get_user_by_id, mock_id_creation):
-        mock_get_user_by_id.return_value = ({"dict"}, 200)
+    def test_get_user_by_id_route(self, mock_get_user_by_id, mock_id_creation, mock_decrypt_address_data):
         mock_id_creation.return_value = ObjectId("60a1444b370ea792caef5419")
-        self.assertEqual(RouteControl().get_user_by_id_route(ObjectId("60a1444b370ea792caef5419")), ({"dict"}, 200))
+        mock_get_user_by_id.return_value = ((dict()), 200)
+        self.assertEqual(rc.get_user_by_id_route("60a1444b370ea792caef5419")[1], 200)
+        mock_get_user_by_id.return_value = ((dict(address=[{
+            "address_number": 77,
+			"address_neighbourhood": "Bairro",
+			"address_postal_code": "00000000",
+			"address_city": "Florianópolis",
+			"address_state": "SC"
+        }])), 200)
+        mock_decrypt_address_data.return_value = [{
+            "address_number": 77,
+			"address_neighbourhood": "Bairro",
+			"address_postal_code": "00000000",
+			"address_city": "Florianópolis",
+			"address_state": "SC"
+        }]
 
-        mock_get_user_by_id.return_value = ({}, 400)
-        mock_id_creation.return_value = ""
-        self.assertEqual(RouteControl().get_user_by_id_route(""), ({}, 400))
+        self.assertEqual(rc.get_user_by_id_route("60a1444b370ea792caef5419")[1], 200)
 
     
     @mock.patch("DataBase.dataBase.DataBase.find_users_by_id")

--- a/Tests/TestControllers/test_tokenController.py
+++ b/Tests/TestControllers/test_tokenController.py
@@ -36,3 +36,10 @@ class TestTokenController(TestCase):
         self.assertEqual(tk.verify_token(token['token_id']), "")
         tk.save_token(token)
         self.assertEqual(tk.verify_token(token['token_id']), token['user_id'])
+        token = {
+                "token_id": "tHpfvw9LVHq9R3rc05GF",
+                "user_id": "UWfDaRdIdzhGaNeMTX9L",
+                "expire": 10 #Validade de 15 minutos nos tokens
+            }
+        tk.save_token(token)
+        self.assertEqual(tk.verify_token(token['token_id']), "")


### PR DESCRIPTION
Os dados do endereço agora são armazenados criptografados. quando requisitados pelo _get_user_by_id_route_ eles são descriptografados e enviados.